### PR TITLE
Fix misuse of .data when plotting processed arrays

### DIFF
--- a/BeamAnalysis.py
+++ b/BeamAnalysis.py
@@ -291,7 +291,7 @@ class BeamAnalysis:
 
         # Figure for Signal
         fig, ax = plt.subplots()
-        im0 = ax.imshow(self.map_array.data, cmap='viridis', extent=extent)
+        im0 = ax.imshow(self.map_array, cmap='viridis', extent=extent)
         ax.set_title("Map")
         ax.set_xlabel("x (um)")
         ax.set_ylabel("y (um)")

--- a/NEC_camera_analysis/Compare_NEC_and_HIKMICRO.py
+++ b/NEC_camera_analysis/Compare_NEC_and_HIKMICRO.py
@@ -37,13 +37,13 @@ class CompareCameras:
                                 figsize=(15, 5))
 
         # Plot NEC
-        rows_NEC, cols_nec = self.NECAnalysis.processed_signal.data.shape
+        rows_NEC, cols_nec = self.NECAnalysis.processed_signal.shape
         extent_NEC = [0, self.NECAnalysis.pixel_size_um * cols_nec, 0, self.NECAnalysis.pixel_size_um * rows_NEC]
         _, NEC_fitting_coefficients, _, _ = self.NECAnalysis.fit_gaussian()
         xo_NEC = NEC_fitting_coefficients['xo']
         yo_NEC = NEC_fitting_coefficients['yo']
 
-        im0 = axs[0].imshow(self.NECAnalysis.processed_signal.data,
+        im0 = axs[0].imshow(self.NECAnalysis.processed_signal,
                             cmap='viridis',
                             extent=extent_NEC)
         axs[0].set_title("NEC")
@@ -71,14 +71,14 @@ class CompareCameras:
                         top_NEC)
 
         # Plot HIKMICRO
-        rows_HIKMICRO, cols_HIKMICRO = self.HIKMICROAnalysis.processed_signal.data.shape
+        rows_HIKMICRO, cols_HIKMICRO = self.HIKMICROAnalysis.processed_signal.shape
         _, HIKMICRO_fitting_coefficients, _, _ = self.HIKMICROAnalysis.fit_gaussian()
         xo_HIKMICRO = HIKMICRO_fitting_coefficients['xo']
         yo_HIKMICRO = HIKMICRO_fitting_coefficients['yo']
         extent_HIKMICRO = [0, self.HIKMICROAnalysis.pixel_size_um * cols_HIKMICRO, 0,
                            self.HIKMICROAnalysis.pixel_size_um * rows_HIKMICRO]
 
-        im1 = axs[1].imshow(self.HIKMICROAnalysis.processed_signal.data,
+        im1 = axs[1].imshow(self.HIKMICROAnalysis.processed_signal,
                             cmap='viridis',
                             extent=extent_HIKMICRO)
         axs[1].set_title("HIKMICRO")


### PR DESCRIPTION
## Summary
- ensure `plot_map_in_pixels` uses the numpy array directly
- drop unnecessary `.data` access in camera comparison

## Testing
- `python -m py_compile BeamAnalysis.py NEC_camera_analysis/Compare_NEC_and_HIKMICRO.py`

------
https://chatgpt.com/codex/tasks/task_e_683fe9694888832e82608e5bbeb457fb